### PR TITLE
Double square brackets for "or" statement

### DIFF
--- a/scripts/build-mongo-for-dev-bundle.sh
+++ b/scripts/build-mongo-for-dev-bundle.sh
@@ -11,7 +11,7 @@ echo BUILDING MONGO "v$MONGO_VERSION" IN "$DIR"
 
 # Check that we are running on a universal environment, otherwise
 # stop and show info about default mongo binary downloads
-if [ -z "$METEOR_UNIVERSAL_FLAG" || "$METEOR_UNIVERSAL_FLAG" == "env" ]; then
+if [ -z "$METEOR_UNIVERSAL_FLAG" ] || [ "$METEOR_UNIVERSAL_FLAG" == "env" ]; then
     echo "We don't know how to build mongo for this architecture"
     exit 1
 fi


### PR DESCRIPTION
Minor fix to prevent errors like:
```
manzato@chip:~/meteor/scripts$ time ./build-mongo-for-dev-bundle.sh 
CHECKOUT DIR IS /home/manzato/meteor
BUILDING MONGO v3.2.6 IN /tmp/generate-dev-bundle-2eK0SL77
./build-mongo-for-dev-bundle.sh: line 14: [: missing `]'
./build-mongo-for-dev-bundle.sh: line 14: arm: command not found
...
```